### PR TITLE
Homescreen widget: countdown + Start/Stop (Droid-assisted)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -34,6 +34,23 @@
             android:enabled="true"
             android:exported="false"
             android:foregroundServiceType="dataSync" />
+
+        <!-- Homescreen widget provider -->
+        <receiver
+            android:name=".WhiteroseWidgetProvider"
+            android:exported="true">
+            <!-- Standard app-widget update broadcast -->
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+                <action android:name="enterprises.meese.whiterose.action.WIDGET_UPDATE" />
+                <action android:name="enterprises.meese.whiterose.action.WIDGET_TOGGLE" />
+            </intent-filter>
+
+            <!-- AppWidget metadata -->
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/whiterose_widget_info" />
+        </receiver>
     </application>
 
 </manifest>

--- a/android/app/src/main/java/enterprises/meese/whiterose/IntervalTimerService.kt
+++ b/android/app/src/main/java/enterprises/meese/whiterose/IntervalTimerService.kt
@@ -28,7 +28,8 @@ class IntervalTimerService : Service() {
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var timerJob: Job? = null
     private var tickerJob: Job? = null
-
+    private val notificationIdCounter = AtomicInteger(NOTIFICATION_ID_DING_BASE)
+    
     // Sound and vibration
     private var soundPool: SoundPool? = null
     private var soundId: Int = 0
@@ -37,6 +38,12 @@ class IntervalTimerService : Service() {
     // Pomodoro tracking
     private var currentPhase: String = "work"
     private var cycleCount: Int = 0
+    
+    // Send broadcast to update widget
+    private fun broadcastWidgetUpdate() {
+        val intent = Intent(WhiteroseWidgetProvider.ACTION_WIDGET_UPDATE)
+        sendBroadcast(intent)
+    }
 
     companion object {
         const val ACTION_START = "enterprises.meese.whiterose.action.START"
@@ -127,6 +134,9 @@ class IntervalTimerService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
             ACTION_STOP -> {
+                val prefs = getSharedPreferences(PREF_NAME, MODE_PRIVATE)
+                prefs.edit().putBoolean(PREF_SERVICE_RUNNING, false).apply()
+                broadcastWidgetUpdate()
                 stopSelf()
                 return START_NOT_STICKY
             }
@@ -144,6 +154,7 @@ class IntervalTimerService : Service() {
                         notify(NOTIFICATION_ID_FOREGROUND, notification)
                     }
                 }
+                broadcastWidgetUpdate()
                 return START_NOT_STICKY
             }
             ACTION_TOGGLE_VIBRATE -> {
@@ -160,6 +171,7 @@ class IntervalTimerService : Service() {
                         notify(NOTIFICATION_ID_FOREGROUND, notification)
                     }
                 }
+                broadcastWidgetUpdate()
                 return START_NOT_STICKY
             }
             ACTION_START -> {
@@ -221,6 +233,9 @@ class IntervalTimerService : Service() {
                 // Start the timer coroutine
                 startIntervalTimer(intervalMinutes)
                 
+                // Update widget
+                broadcastWidgetUpdate()
+                
                 return START_REDELIVER_INTENT
             }
             else -> return START_NOT_STICKY
@@ -235,6 +250,7 @@ class IntervalTimerService : Service() {
         tickerJob = serviceScope.launch {
             while (isActive) {
                 val prefs = getSharedPreferences(PREF_NAME, MODE_PRIVATE)
+                val nextTriggerMs = prefs.getLong(PREF_NEXT_TRIGGER_MS, 0L)
                 val intervalMinutes = prefs.getInt(PREF_INTERVAL_MINUTES, DEFAULT_INTERVAL_MINUTES)
                 
                 // Update the foreground notification with the countdown
@@ -244,6 +260,9 @@ class IntervalTimerService : Service() {
                         notify(NOTIFICATION_ID_FOREGROUND, notification)
                     }
                 }
+                
+                // Update widget every second
+                broadcastWidgetUpdate()
                 
                 delay(1000) // Update every second
             }
@@ -346,7 +365,12 @@ class IntervalTimerService : Service() {
             } else {
                 @Suppress("DEPRECATION")
                 val vibrator = getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
-                vibrator.vibrate(VibrationEffect.createOneShot(durationMs, VibrationEffect.DEFAULT_AMPLITUDE))
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    vibrator.vibrate(VibrationEffect.createOneShot(durationMs, VibrationEffect.DEFAULT_AMPLITUDE))
+                } else {
+                    @Suppress("DEPRECATION")
+                    vibrator.vibrate(durationMs)
+                }
             }
         } catch (e: Exception) {
             // Ignore vibration errors
@@ -381,34 +405,36 @@ class IntervalTimerService : Service() {
     }
 
     private fun createNotificationChannels() {
-        // Create the tracker channel (low importance, no sound)
-        val trackerChannel = NotificationChannel(
-            CHANNEL_ID_TRACKER,
-            "Time Tracker",
-            NotificationManager.IMPORTANCE_LOW
-        ).apply {
-            description = "Shows the time tracking service is running"
-            enableLights(false)
-            enableVibration(false)
-            setShowBadge(false)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // Create the tracker channel (low importance, no sound)
+            val trackerChannel = NotificationChannel(
+                CHANNEL_ID_TRACKER,
+                "Time Tracker",
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = "Shows the time tracking service is running"
+                enableLights(false)
+                enableVibration(false)
+                setShowBadge(false)
+            }
+            
+            // Create the ding channel (high importance, with sound and vibration)
+            val dingChannel = NotificationChannel(
+                CHANNEL_ID_DING,
+                "Time Intervals",
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = "Alerts when time intervals have passed"
+                enableLights(true)
+                enableVibration(true)
+                setShowBadge(true)
+            }
+            
+            // Register both channels
+            val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(trackerChannel)
+            notificationManager.createNotificationChannel(dingChannel)
         }
-
-        // Create the ding channel (high importance, with sound and vibration)
-        val dingChannel = NotificationChannel(
-            CHANNEL_ID_DING,
-            "Time Intervals",
-            NotificationManager.IMPORTANCE_HIGH
-        ).apply {
-            description = "Alerts when time intervals have passed"
-            enableLights(true)
-            enableVibration(true)
-            setShowBadge(true)
-        }
-
-        // Register both channels
-        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        notificationManager.createNotificationChannel(trackerChannel)
-        notificationManager.createNotificationChannel(dingChannel)
     }
 
     private fun createForegroundNotification(intervalMinutes: Int): android.app.Notification {
@@ -515,6 +541,9 @@ class IntervalTimerService : Service() {
             .edit()
             .putBoolean(PREF_SERVICE_RUNNING, false)
             .apply()
+        
+        // Update widget one last time
+        broadcastWidgetUpdate()
         
         // Clean up resources
         timerJob?.cancel()

--- a/android/app/src/main/java/enterprises/meese/whiterose/IntervalTimerService.kt
+++ b/android/app/src/main/java/enterprises/meese/whiterose/IntervalTimerService.kt
@@ -6,6 +6,7 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.ComponentName
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.media.AudioAttributes
@@ -39,9 +40,25 @@ class IntervalTimerService : Service() {
     private var currentPhase: String = "work"
     private var cycleCount: Int = 0
     
-    // Send broadcast to update widget
-    private fun broadcastWidgetUpdate() {
-        val intent = Intent(WhiteroseWidgetProvider.ACTION_WIDGET_UPDATE)
+    /**
+     * Refresh homescreen widget immediately.
+     *
+     * 1. Invoke the provider’s static helper to update all instances directly
+     *    via AppWidgetManager.
+     * 2. Also send an explicit broadcast (component-targeted) so any queued
+     *    receivers still trigger on older OS versions that rely on it.
+     */
+    private fun updateWidgetNow() {
+        // Direct AppWidgetManager update
+        WhiteroseWidgetProvider.updateAll(applicationContext)
+
+        // Fallback explicit broadcast
+        val intent = Intent(WhiteroseWidgetProvider.ACTION_WIDGET_UPDATE).apply {
+            component = ComponentName(
+                applicationContext,
+                WhiteroseWidgetProvider::class.java
+            )
+        }
         sendBroadcast(intent)
     }
 
@@ -136,7 +153,7 @@ class IntervalTimerService : Service() {
             ACTION_STOP -> {
                 val prefs = getSharedPreferences(PREF_NAME, MODE_PRIVATE)
                 prefs.edit().putBoolean(PREF_SERVICE_RUNNING, false).apply()
-                broadcastWidgetUpdate()
+                updateWidgetNow()
                 stopSelf()
                 return START_NOT_STICKY
             }
@@ -154,7 +171,7 @@ class IntervalTimerService : Service() {
                         notify(NOTIFICATION_ID_FOREGROUND, notification)
                     }
                 }
-                broadcastWidgetUpdate()
+                updateWidgetNow()
                 return START_NOT_STICKY
             }
             ACTION_TOGGLE_VIBRATE -> {
@@ -171,7 +188,7 @@ class IntervalTimerService : Service() {
                         notify(NOTIFICATION_ID_FOREGROUND, notification)
                     }
                 }
-                broadcastWidgetUpdate()
+                updateWidgetNow()
                 return START_NOT_STICKY
             }
             ACTION_START -> {
@@ -234,7 +251,7 @@ class IntervalTimerService : Service() {
                 startIntervalTimer(intervalMinutes)
                 
                 // Update widget
-                broadcastWidgetUpdate()
+                updateWidgetNow()
                 
                 return START_REDELIVER_INTENT
             }
@@ -262,7 +279,7 @@ class IntervalTimerService : Service() {
                 }
                 
                 // Update widget every second
-                broadcastWidgetUpdate()
+                updateWidgetNow()
                 
                 delay(1000) // Update every second
             }
@@ -543,7 +560,7 @@ class IntervalTimerService : Service() {
             .apply()
         
         // Update widget one last time
-        broadcastWidgetUpdate()
+        updateWidgetNow()
         
         // Clean up resources
         timerJob?.cancel()

--- a/android/app/src/main/java/enterprises/meese/whiterose/MainActivity.kt
+++ b/android/app/src/main/java/enterprises/meese/whiterose/MainActivity.kt
@@ -224,6 +224,7 @@ fun SettingsScreen(viewModel: ViewModel, onClose: () -> Unit) {
     val pomoBreakMin by viewModel.pomoBreakMin.collectAsState()
     val pomoLongMin by viewModel.pomoLongMin.collectAsState()
     val pomoLongEvery by viewModel.pomoLongEvery.collectAsState()
+    val widgetMaterial by viewModel.widgetMaterial.collectAsState()
 
     var text by remember(interval) { mutableStateOf(interval.toString()) }
     var workText by remember(pomoWorkMin) { mutableStateOf(pomoWorkMin.toString()) }

--- a/android/app/src/main/java/enterprises/meese/whiterose/MainActivity.kt
+++ b/android/app/src/main/java/enterprises/meese/whiterose/MainActivity.kt
@@ -47,12 +47,7 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun WhiteroseApp(viewModel: ViewModel = viewModel()) {
-    val interval by viewModel.intervalMinutes.collectAsState()
     val serviceRunning by viewModel.serviceRunning.collectAsState()
-    val alignToClock by viewModel.alignToClock.collectAsState()
-    val playSound by viewModel.playSound.collectAsState()
-    val vibrate by viewModel.vibrate.collectAsState()
-    val widgetMaterial by viewModel.widgetMaterial.collectAsState()
     val mode by viewModel.mode.collectAsState()
     val nextTriggerMs by viewModel.nextTriggerMs.collectAsState()
     val currentPhase by viewModel.currentPhase.collectAsState()

--- a/android/app/src/main/java/enterprises/meese/whiterose/MainActivity.kt
+++ b/android/app/src/main/java/enterprises/meese/whiterose/MainActivity.kt
@@ -52,6 +52,7 @@ fun WhiteroseApp(viewModel: ViewModel = viewModel()) {
     val alignToClock by viewModel.alignToClock.collectAsState()
     val playSound by viewModel.playSound.collectAsState()
     val vibrate by viewModel.vibrate.collectAsState()
+    val widgetMaterial by viewModel.widgetMaterial.collectAsState()
     val mode by viewModel.mode.collectAsState()
     val nextTriggerMs by viewModel.nextTriggerMs.collectAsState()
     val currentPhase by viewModel.currentPhase.collectAsState()
@@ -398,6 +399,17 @@ fun SettingsScreen(viewModel: ViewModel, onClose: () -> Unit) {
                 Text("Vibrate")
                 Spacer(Modifier.width(8.dp))
                 Switch(checked = vibrate, onCheckedChange = { viewModel.setVibrate(it) })
+            }
+
+            /* Widget Material You toggle */
+            Spacer(Modifier.height(16.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("Widget uses Material You")
+                Spacer(Modifier.width(8.dp))
+                Switch(
+                    checked = widgetMaterial,
+                    onCheckedChange = { viewModel.setWidgetMaterial(it) }
+                )
             }
 
             /* Mode selection – vertical */

--- a/android/app/src/main/java/enterprises/meese/whiterose/MainActivity.kt
+++ b/android/app/src/main/java/enterprises/meese/whiterose/MainActivity.kt
@@ -47,7 +47,12 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun WhiteroseApp(viewModel: ViewModel = viewModel()) {
+    val interval by viewModel.intervalMinutes.collectAsState()
     val serviceRunning by viewModel.serviceRunning.collectAsState()
+    val alignToClock by viewModel.alignToClock.collectAsState()
+    val playSound by viewModel.playSound.collectAsState()
+    val vibrate by viewModel.vibrate.collectAsState()
+    val widgetMaterial by viewModel.widgetMaterial.collectAsState()
     val mode by viewModel.mode.collectAsState()
     val nextTriggerMs by viewModel.nextTriggerMs.collectAsState()
     val currentPhase by viewModel.currentPhase.collectAsState()
@@ -407,6 +412,12 @@ fun SettingsScreen(viewModel: ViewModel, onClose: () -> Unit) {
                     onCheckedChange = { viewModel.setWidgetMaterial(it) }
                 )
             }
+
+            Spacer(Modifier.height(4.dp))
+            Text(
+                "If changes don't apply immediately, remove and re-add the widget.",
+                style = MaterialTheme.typography.bodySmall
+            )
 
             /* Mode selection – vertical */
             Spacer(Modifier.height(24.dp))

--- a/android/app/src/main/java/enterprises/meese/whiterose/ViewModel.kt
+++ b/android/app/src/main/java/enterprises/meese/whiterose/ViewModel.kt
@@ -1,6 +1,7 @@
 package enterprises.meese.whiterose
 
 import android.app.Application
+import android.content.Intent
 import android.content.SharedPreferences
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
@@ -48,6 +49,10 @@ class ViewModel(application: Application) : AndroidViewModel(application) {
     private val _pomoLongEvery = MutableStateFlow(prefs.getInt("pomo_long_every", 4))
     val pomoLongEvery = _pomoLongEvery.asStateFlow()
 
+    /* ----------------------- Widget appearance toggle ---------------------- */
+    private val _widgetMaterial = MutableStateFlow(prefs.getBoolean("widget_material", true))
+    val widgetMaterial = _widgetMaterial.asStateFlow()
+
     private val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, key ->
         when (key) {
             "interval_minutes" -> _intervalMinutes.value = prefs.getInt("interval_minutes", 5)
@@ -62,6 +67,7 @@ class ViewModel(application: Application) : AndroidViewModel(application) {
             "pomo_break_min" -> _pomoBreakMin.value = prefs.getInt("pomo_break_min", 5)
             "pomo_long_min" -> _pomoLongMin.value = prefs.getInt("pomo_long_min", 15)
             "pomo_long_every" -> _pomoLongEvery.value = prefs.getInt("pomo_long_every", 4)
+            "widget_material" -> _widgetMaterial.value = prefs.getBoolean("widget_material", true)
         }
     }
 
@@ -135,6 +141,19 @@ class ViewModel(application: Application) : AndroidViewModel(application) {
         viewModelScope.launch {
             _pomoLongEvery.emit(cycles)
             prefs.edit().putInt("pomo_long_every", cycles).apply()
+        }
+    }
+
+    /* ---------------- Widget style setter ---------------- */
+    fun setWidgetMaterial(enabled: Boolean) {
+        viewModelScope.launch {
+            _widgetMaterial.emit(enabled)
+            prefs.edit().putBoolean("widget_material", enabled).apply()
+
+            // Broadcast to refresh widgets immediately
+            val ctx = getApplication<Application>()
+            val intent = Intent(WhiteroseWidgetProvider.ACTION_WIDGET_UPDATE)
+            ctx.sendBroadcast(intent)
         }
     }
 

--- a/android/app/src/main/java/enterprises/meese/whiterose/WhiteroseWidgetProvider.kt
+++ b/android/app/src/main/java/enterprises/meese/whiterose/WhiteroseWidgetProvider.kt
@@ -1,0 +1,141 @@
+package enterprises.meese.whiterose
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.widget.RemoteViews
+import java.util.Locale
+import kotlin.math.ceil
+
+/**
+ * Implementation of App Widget functionality for Whiterose timer.
+ * Shows current status, remaining time, and provides Start/Stop button.
+ */
+class WhiteroseWidgetProvider : AppWidgetProvider() {
+
+    companion object {
+        const val ACTION_WIDGET_UPDATE = "enterprises.meese.whiterose.action.WIDGET_UPDATE"
+        const val ACTION_WIDGET_TOGGLE = "enterprises.meese.whiterose.action.WIDGET_TOGGLE"
+        
+        private const val PREF_NAME = "whiterose_prefs"
+        
+        /**
+         * Updates all widget instances
+         */
+        fun updateAll(context: Context) {
+            val appWidgetManager = AppWidgetManager.getInstance(context)
+            val appWidgetIds = appWidgetManager.getAppWidgetIds(
+                ComponentName(context, WhiteroseWidgetProvider::class.java)
+            )
+            
+            if (appWidgetIds.isNotEmpty()) {
+                // Update all widgets
+                appWidgetManager.updateAppWidget(appWidgetIds, buildRemoteViews(context))
+            }
+        }
+        
+        /**
+         * Builds the RemoteViews for the widget
+         */
+        private fun buildRemoteViews(context: Context): RemoteViews {
+            val views = RemoteViews(context.packageName, R.layout.whiterose_widget)
+            
+            // Get preferences
+            val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+            val serviceRunning = prefs.getBoolean("service_running", false)
+            val nextTriggerMs = prefs.getLong("next_trigger_ms", 0L)
+            val mode = prefs.getString("mode", IntervalTimerService.MODE_SIMPLE) ?: IntervalTimerService.MODE_SIMPLE
+            val currentPhase = prefs.getString("current_phase", "work") ?: "work"
+            val intervalMinutes = prefs.getInt("interval_minutes", 5)
+            
+            // Format remaining time
+            val timeText = if (serviceRunning) {
+                val remainingMs = (nextTriggerMs - System.currentTimeMillis()).coerceAtLeast(0L)
+                // Use ceiling to avoid off-by-one truncation
+                val remainingSecTotal = ceil(remainingMs / 1000.0).toLong()
+                val mins = (remainingSecTotal / 60).toInt()
+                val secs = (remainingSecTotal % 60).toInt()
+                String.format(Locale.US, "%02d:%02d", mins, secs)
+            } else {
+                "--:--"
+            }
+            
+            // Set time text
+            views.setTextViewText(R.id.txtTime, timeText)
+            
+            // Set phase text
+            val phaseText = if (!serviceRunning) {
+                "Stopped"
+            } else if (mode == IntervalTimerService.MODE_SIMPLE) {
+                "Simple"
+            } else {
+                val phaseLabel = if (currentPhase == "work") "Work" else "Break"
+                "$phaseLabel"
+            }
+            views.setTextViewText(R.id.txtPhase, phaseText)
+            
+            // Set button text
+            val buttonText = if (serviceRunning) {
+                context.getString(R.string.btn_stop)
+            } else {
+                context.getString(R.string.btn_start)
+            }
+            views.setTextViewText(R.id.btnToggle, buttonText)
+            
+            // Set button click action
+            val toggleIntent = Intent(context, WhiteroseWidgetProvider::class.java).apply {
+                action = ACTION_WIDGET_TOGGLE
+            }
+            val pendingFlags = PendingIntent.FLAG_UPDATE_CURRENT or 
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
+            
+            val togglePendingIntent = PendingIntent.getBroadcast(
+                context, 0, toggleIntent, pendingFlags
+            )
+            views.setOnClickPendingIntent(R.id.btnToggle, togglePendingIntent)
+            
+            return views
+        }
+    }
+    
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        // Update all widgets
+        updateAll(context)
+    }
+    
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+        
+        when (intent.action) {
+            ACTION_WIDGET_UPDATE -> {
+                // Update all widgets
+                updateAll(context)
+            }
+            ACTION_WIDGET_TOGGLE -> {
+                // Toggle service state
+                val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+                val serviceRunning = prefs.getBoolean("service_running", false)
+                
+                if (serviceRunning) {
+                    // Stop service
+                    IntervalTimerService.stopService(context)
+                } else {
+                    // Start service with current interval
+                    val intervalMinutes = prefs.getInt("interval_minutes", 5)
+                    IntervalTimerService.startService(context, intervalMinutes)
+                }
+                
+                // Update widgets immediately for better UX
+                updateAll(context)
+            }
+        }
+    }
+}

--- a/android/app/src/main/java/enterprises/meese/whiterose/WhiteroseWidgetProvider.kt
+++ b/android/app/src/main/java/enterprises/meese/whiterose/WhiteroseWidgetProvider.kt
@@ -86,16 +86,29 @@ class WhiteroseWidgetProvider : AppWidgetProvider() {
             }
             views.setTextViewText(R.id.btnToggle, buttonText)
             
-            // Set button click action
-            val toggleIntent = Intent(context, WhiteroseWidgetProvider::class.java).apply {
-                action = ACTION_WIDGET_TOGGLE
+            // Build PendingIntent that directly starts/stops the foreground service
+            val pendingFlags = PendingIntent.FLAG_UPDATE_CURRENT or
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
+
+            val serviceIntent: Intent = if (serviceRunning) {
+                // Stop the timer
+                Intent(context, IntervalTimerService::class.java).apply {
+                    action = IntervalTimerService.ACTION_STOP
+                }
+            } else {
+                // Start the timer with the user-selected interval
+                Intent(context, IntervalTimerService::class.java).apply {
+                    action = IntervalTimerService.ACTION_START
+                    putExtra(IntervalTimerService.EXTRA_INTERVAL_MINUTES, intervalMinutes)
+                }
             }
-            val pendingFlags = PendingIntent.FLAG_UPDATE_CURRENT or 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0
-            
-            val togglePendingIntent = PendingIntent.getBroadcast(
-                context, 0, toggleIntent, pendingFlags
-            )
+
+            val togglePendingIntent: PendingIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                PendingIntent.getForegroundService(context, 0, serviceIntent, pendingFlags)
+            } else {
+                PendingIntent.getService(context, 0, serviceIntent, pendingFlags)
+            }
+
             views.setOnClickPendingIntent(R.id.btnToggle, togglePendingIntent)
             
             return views

--- a/android/app/src/main/java/enterprises/meese/whiterose/WhiteroseWidgetProvider.kt
+++ b/android/app/src/main/java/enterprises/meese/whiterose/WhiteroseWidgetProvider.kt
@@ -33,13 +33,16 @@ class WhiteroseWidgetProvider : AppWidgetProvider() {
                 val minWidth = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, 0)
                 val minHeight = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT, 0)
                 
-                // Use large layout if widget is big enough
-                if (minWidth >= 200 && minHeight >= 120) {
+                // Compact if either dimension is below our large-layout threshold
+                // (≈ 3×2 cells ~ 180×110 dp).  Otherwise use large layout.
+                if (minWidth < 180 || minHeight < 110) {
+                    return R.layout.whiterose_widget_compact
+                } else {
                     return R.layout.whiterose_widget
                 }
             }
             
-            // Default to compact layout
+            // Fallback when options unavailable
             return R.layout.whiterose_widget_compact
         }
         
@@ -124,8 +127,9 @@ class WhiteroseWidgetProvider : AppWidgetProvider() {
             
             // Determine background color (try dynamic color first, fallback to semi-transparent black)
             var bgColor = 0xCC000000.toInt() // Default: semi-transparent black
+            val useMaterial = prefs.getBoolean("widget_material", true)
             
-            if (Build.VERSION.SDK_INT >= 31) { // Android 12+
+            if (useMaterial && Build.VERSION.SDK_INT >= 31) { // Android 12+ and user allows Material You
                 try {
                     // Try to get system accent color
                     val accentColor = context.getColor(android.R.color.system_accent1_800)

--- a/android/app/src/main/java/enterprises/meese/whiterose/WhiteroseWidgetProvider.kt
+++ b/android/app/src/main/java/enterprises/meese/whiterose/WhiteroseWidgetProvider.kt
@@ -7,6 +7,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.os.Bundle
 import android.widget.RemoteViews
 import java.util.Locale
 import kotlin.math.ceil
@@ -24,6 +25,25 @@ class WhiteroseWidgetProvider : AppWidgetProvider() {
         private const val PREF_NAME = "whiterose_prefs"
         
         /**
+         * Choose the appropriate layout based on widget size
+         */
+        private fun chooseLayoutRes(context: Context, options: Bundle?): Int {
+            if (options != null) {
+                // Get min width and height in dp
+                val minWidth = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_WIDTH, 0)
+                val minHeight = options.getInt(AppWidgetManager.OPTION_APPWIDGET_MIN_HEIGHT, 0)
+                
+                // Use large layout if widget is big enough
+                if (minWidth >= 200 && minHeight >= 120) {
+                    return R.layout.whiterose_widget
+                }
+            }
+            
+            // Default to compact layout
+            return R.layout.whiterose_widget_compact
+        }
+        
+        /**
          * Updates all widget instances
          */
         fun updateAll(context: Context) {
@@ -32,17 +52,33 @@ class WhiteroseWidgetProvider : AppWidgetProvider() {
                 ComponentName(context, WhiteroseWidgetProvider::class.java)
             )
             
-            if (appWidgetIds.isNotEmpty()) {
-                // Update all widgets
-                appWidgetManager.updateAppWidget(appWidgetIds, buildRemoteViews(context))
+            // Update each widget individually
+            for (appWidgetId in appWidgetIds) {
+                updateSingle(context, appWidgetManager, appWidgetId)
             }
+        }
+        
+        /**
+         * Updates a single widget instance
+         */
+        private fun updateSingle(context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int) {
+            // Get widget options to determine size
+            val options = appWidgetManager.getAppWidgetOptions(appWidgetId)
+            
+            // Build RemoteViews with the appropriate layout
+            val views = buildRemoteViews(context, options)
+            
+            // Update the widget
+            appWidgetManager.updateAppWidget(appWidgetId, views)
         }
         
         /**
          * Builds the RemoteViews for the widget
          */
-        private fun buildRemoteViews(context: Context): RemoteViews {
-            val views = RemoteViews(context.packageName, R.layout.whiterose_widget)
+        private fun buildRemoteViews(context: Context, options: Bundle? = null): RemoteViews {
+            // Choose layout based on size
+            val layoutId = chooseLayoutRes(context, options)
+            val views = RemoteViews(context.packageName, layoutId)
             
             // Get preferences
             val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
@@ -67,7 +103,7 @@ class WhiteroseWidgetProvider : AppWidgetProvider() {
             // Set time text
             views.setTextViewText(R.id.txtTime, timeText)
             
-            // Set phase text
+            // Set phase text (always set even if hidden in compact layout)
             val phaseText = if (!serviceRunning) {
                 "Stopped"
             } else if (mode == IntervalTimerService.MODE_SIMPLE) {
@@ -85,6 +121,23 @@ class WhiteroseWidgetProvider : AppWidgetProvider() {
                 context.getString(R.string.btn_start)
             }
             views.setTextViewText(R.id.btnToggle, buttonText)
+            
+            // Determine background color (try dynamic color first, fallback to semi-transparent black)
+            var bgColor = 0xCC000000.toInt() // Default: semi-transparent black
+            
+            if (Build.VERSION.SDK_INT >= 31) { // Android 12+
+                try {
+                    // Try to get system accent color
+                    val accentColor = context.getColor(android.R.color.system_accent1_800)
+                    // Apply alpha for translucency
+                    bgColor = (0xCC000000.toInt() and 0xFF000000.toInt()) or (accentColor and 0x00FFFFFF)
+                } catch (e: Exception) {
+                    // Fallback to default if system color not available
+                }
+            }
+            
+            // Apply background color
+            views.setInt(R.id.bg, "setColorFilter", bgColor)
             
             // Build PendingIntent that directly starts/stops the foreground service
             val pendingFlags = PendingIntent.FLAG_UPDATE_CURRENT or
@@ -121,7 +174,19 @@ class WhiteroseWidgetProvider : AppWidgetProvider() {
         appWidgetIds: IntArray
     ) {
         // Update all widgets
-        updateAll(context)
+        for (appWidgetId in appWidgetIds) {
+            updateSingle(context, appWidgetManager, appWidgetId)
+        }
+    }
+    
+    override fun onAppWidgetOptionsChanged(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetId: Int,
+        newOptions: Bundle?
+    ) {
+        // Widget size changed, update it
+        updateSingle(context, appWidgetManager, appWidgetId)
     }
     
     override fun onReceive(context: Context, intent: Intent) {

--- a/android/app/src/main/res/drawable/widget_bg_shape.xml
+++ b/android/app/src/main/res/drawable/widget_bg_shape.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    
+    <!-- Rounded corners with 16dp radius -->
+    <corners android:radius="16dp" />
+    
+    <!-- White fill color for tinting -->
+    <solid android:color="#FFFFFFFF" />
+    
+</shape>

--- a/android/app/src/main/res/layout/whiterose_widget.xml
+++ b/android/app/src/main/res/layout/whiterose_widget.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="8dp"
+    android:background="#CC000000"
+    android:gravity="center">
+
+    <!-- Time countdown display -->
+    <TextView
+        android:id="@+id/txtTime"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="24sp"
+        android:textColor="#FFFFFF"
+        android:textStyle="bold"
+        android:text="--:--" />
+
+    <!-- Phase display (Work/Break/Stopped) -->
+    <TextView
+        android:id="@+id/txtPhase"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="12sp"
+        android:textColor="#AAAAAA"
+        android:text="Stopped" />
+
+    <!-- Start/Stop button -->
+    <Button
+        android:id="@+id/btnToggle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dp"
+        android:text="Start"
+        android:textColor="#FFFFFF"
+        android:background="@android:color/transparent"
+        style="@android:style/Widget.DeviceDefault.Button.Borderless" />
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/whiterose_widget_compact.xml
+++ b/android/app/src/main/res/layout/whiterose_widget_compact.xml
@@ -20,24 +20,25 @@
         android:orientation="vertical"
         android:gravity="center">
 
-        <!-- Time countdown display -->
+        <!-- Time countdown display - smaller text -->
         <TextView
             android:id="@+id/txtTime"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="24sp"
+            android:textSize="20sp"
             android:textColor="#FFFFFF"
             android:textStyle="bold"
             android:text="--:--" />
 
-        <!-- Phase display (Work/Break/Stopped) -->
+        <!-- Phase display (hidden in compact mode) -->
         <TextView
             android:id="@+id/txtPhase"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="12sp"
             android:textColor="#AAAAAA"
-            android:text="Stopped" />
+            android:text="Stopped"
+            android:visibility="gone" />
 
         <!-- Start/Stop button -->
         <Button

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -29,4 +29,7 @@
     <string name="next_in_label">Next in %1$s</string>
     <string name="phase_work">Work</string>
     <string name="phase_break">Break</string>
+
+    <!-- Widget -->
+    <string name="widget_stopped">Stopped</string>
 </resources>

--- a/android/app/src/main/res/xml/whiterose_widget_info.xml
+++ b/android/app/src/main/res/xml/whiterose_widget_info.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    android:minWidth="250dp"
-    android:minHeight="80dp"
+    <!-- Allow placement as small as 2×1 cells (~110×60 dp) -->
+    android:minWidth="110dp"
+    android:minHeight="60dp"
+    android:minResizeWidth="110dp"
+    android:minResizeHeight="60dp"
     android:updatePeriodMillis="0"
     android:initialLayout="@layout/whiterose_widget"
     android:resizeMode="horizontal|vertical"

--- a/android/app/src/main/res/xml/whiterose_widget_info.xml
+++ b/android/app/src/main/res/xml/whiterose_widget_info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Allow placement as small as 2×1 cells (~110×60 dp) -->
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
-    <!-- Allow placement as small as 2×1 cells (~110×60 dp) -->
     android:minWidth="110dp"
     android:minHeight="60dp"
     android:minResizeWidth="110dp"

--- a/android/app/src/main/res/xml/whiterose_widget_info.xml
+++ b/android/app/src/main/res/xml/whiterose_widget_info.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="80dp"
+    android:updatePeriodMillis="0"
+    android:initialLayout="@layout/whiterose_widget"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen"
+    android:targetCellWidth="2"
+    android:targetCellHeight="1" />


### PR DESCRIPTION
Adds a simple 2×1 homescreen widget for Whiterose.

Highlights
- Widget shows:
  • Remaining time (mm:ss) using ceiling conversion to complement the clock
  • Phase label: Work/Break/Simple or Stopped when service is off
  • Start/Stop button that toggles the service
- Updates are pushed once per second while the service runs (and on state changes) via a lightweight broadcast from the service ticker.
- Receiver + provider info registered; no gradle changes required.

Files
- java/…/WhiteroseWidgetProvider.kt — AppWidgetProvider
- res/layout/whiterose_widget.xml — widget layout (2×1)
- res/xml/whiterose_widget_info.xml — provider meta
- AndroidManifest.xml — receiver registration
- IntervalTimerService.kt — emits widget update broadcast on ticks and state changes

Notes
- Update period is driven by the service; when stopped, widget shows “Stopped” and --:--.

Droid-assisted PR.

---
**Factory Session:** https://app.factory.ai/sessions/n3ZABFtw4pOI9rw7hdhM (created by aaron@meese.dev)