### PR TITLE
feat(dnd): auto-mute chime during DND or calls

### DIFF
--- a/android/app/src/main/java/enterprises/meese/whiterose/IntervalTimerService.kt
+++ b/android/app/src/main/java/enterprises/meese/whiterose/IntervalTimerService.kt
@@ -11,6 +11,7 @@ import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
 import android.media.AudioAttributes
 import android.media.SoundPool
+import android.media.AudioManager
 import android.os.Build
 import android.os.IBinder
 import android.os.VibrationEffect
@@ -309,8 +310,8 @@ class IntervalTimerService : Service() {
                 // Wait for the interval
                 delay(delayMs)
                 
-                // Play sound if enabled
-                if (playSound && soundLoaded) {
+                // Play sound if enabled and not in DND or on a call
+                if (playSound && soundLoaded && !isInDoNotDisturb() && !isOnCall()) {
                     soundPool?.play(soundId, 1f, 1f, 1, 0, 1f)
                 }
                 
@@ -419,6 +420,28 @@ class IntervalTimerService : Service() {
         val minutes = (millisUntil / (1000 * 60)) % 60
         
         return String.format(Locale.US, "%02d:%02d", minutes, seconds)
+    }
+
+    /**
+     * Returns true if system is currently in a Do Not Disturb interruption mode
+     * that should suppress notification sounds.
+     */
+    private fun isInDoNotDisturb(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.currentInterruptionFilter != NotificationManager.INTERRUPTION_FILTER_ALL
+        } else {
+            false
+        }
+    }
+
+    /**
+     * Returns true when the device audio mode indicates an active call or VoIP
+     * session so that chimes should be muted.
+     */
+    private fun isOnCall(): Boolean {
+        val am = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        return am.mode == AudioManager.MODE_IN_CALL || am.mode == AudioManager.MODE_IN_COMMUNICATION
     }
 
     private fun createNotificationChannels() {


### PR DESCRIPTION
This PR adds Do Not Disturb (DND) and call awareness to Whiterose's interval chime.

What’s changed
- Suppress sound playback when the system is in DND or the device audio mode indicates an active call/VoIP session.
- No new settings, toggles, or variables added. Existing sound/vibration toggles continue to work as before.
- Implementation details:
  - Uses NotificationManager.currentInterruptionFilter to detect DND (SDK >= 23). If not ALL, the chime is muted.
  - Uses AudioManager.mode to detect MODE_IN_CALL or MODE_IN_COMMUNICATION and mutes chime while active.

Notes
- No extra permissions requested; we only read system state that is available without Notification Policy access or phone state permissions.
- Build not executed in this environment due to missing Android SDK, but the change is self-contained to service logic.

Droid-assisted PR.

---
**Factory Session:** https://app.factory.ai/sessions/n3ZABFtw4pOI9rw7hdhM (created by aaron@meese.dev)